### PR TITLE
Python regex timeouts

### DIFF
--- a/Agent.Plugins.Log.TestResultParser.Parser/Parser/Python/PythonRegexes.cs
+++ b/Agent.Plugins.Log.TestResultParser.Parser/Parser/Python/PythonRegexes.cs
@@ -13,10 +13,19 @@ namespace Agent.Plugins.Log.TestResultParser.Parser
         /// </summary>
         private static readonly TimeSpan RegexDefaultTimeout = TimeSpan.FromMilliseconds(100);
 
+        /// <summary>
+        /// Timeout for TestResult regex
+        /// </summary>
+        private static readonly TimeSpan TestResultRegexTimeout = TimeSpan.FromMilliseconds(200);
+
+        // Pattern : " ... "
+        // Example : test1 (testProject) ... ok
+        public static Regex TestResultIdentifier { get; } = new Regex($" \\.\\.\\. ", RegexOptions.ExplicitCapture, RegexDefaultTimeout);
+
         // Pattern : ^(.+) ... (.*)$
         // Example : test1 (testProject) ... ok
         public static Regex TestResult { get; } = new Regex($"^(?<{RegexCaptureGroups.TestCaseName}>.+) \\.\\.\\. (?<{RegexCaptureGroups.TestOutcome}>.*)$",
-            RegexOptions.ExplicitCapture, RegexDefaultTimeout);
+            RegexOptions.ExplicitCapture, TestResultRegexTimeout);
 
         // TODO: Have separate pattern for error if required
         // Pattern : ^(FAIL|ERROR)( )?:(.+)$

--- a/Agent.Plugins.Log.TestResultParser.Parser/Parser/Python/PythonTestResultParser.cs
+++ b/Agent.Plugins.Log.TestResultParser.Parser/Parser/Python/PythonTestResultParser.cs
@@ -196,12 +196,16 @@ namespace Agent.Plugins.Log.TestResultParser.Parser
 
         private bool TryParseTestResult(LogData logData)
         {
-            var resultMatch = PythonRegexes.TestResult.Match(logData.Line);
+            // TestResultIdentifier regex is 10x faster than the actual TestResult regex
+            // There is little extra cost for re-parse for success but there is huge save during mismatchs
+            var resultMatch = PythonRegexes.TestResultIdentifier.Match(logData.Line);
 
             if (!resultMatch.Success)
             {
                 return _partialTestResult == null ? false : TryParseForPartialResult(logData);
             }
+
+            resultMatch = PythonRegexes.TestResult.Match(logData.Line);
 
             _partialTestResult = null;
 

--- a/Agent.Plugins.UnitTests/PythonTestResultParserTests/Resources/RegexTests/NegativeMatches/TestResultIdentifier.txt
+++ b/Agent.Plugins.UnitTests/PythonTestResultParserTests/Resources/RegexTests/NegativeMatches/TestResultIdentifier.txt
@@ -1,0 +1,7 @@
+﻿
+.. ok
+... ok
+.... ok
+abcd ..... ok
+testHello ...
+testHello .. HelloWorld

--- a/Agent.Plugins.UnitTests/PythonTestResultParserTests/Resources/RegexTests/PositiveMatches/TestResultIdentifier.txt
+++ b/Agent.Plugins.UnitTests/PythonTestResultParserTests/Resources/RegexTests/PositiveMatches/TestResultIdentifier.txt
@@ -1,0 +1,10 @@
+﻿abc ... abc
+testHello ... HelloWorld
+testHello ... skipped
+testHello ... skipped 'reason'
+testHello ... ok
+testHello (testProject) ... ok
+testHello (testProject) ... Hello world ok
+testHello (testProject) ... Hello world expected failure
+testHello (testProject) ... Hello world failed
+testHello (testProject) ... Hello world failed


### PR DESCRIPTION
Fix for the python regex timing out.

Details :
- Increased the timeout for the TestResult regex, as it is slower than the rest.
- Using Faster regex for identification